### PR TITLE
feat: add HTTP logging middleware for enhanced request tracking

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,9 @@ func runGatewayServer(config util.Config, store db.Store) {
 	}
 
 	log.Info().Msgf("start Http gateway server listening on %s", listener.Addr().String())
-	err = http.Serve(listener, mux)
+	// 미들웨어 추가
+	handler := gapi.HttpLogger(mux)
+	err = http.Serve(listener, handler)
 	if err != nil {
 		log.Fatal().Msg("cannot start HTTP gateway server")
 	}


### PR DESCRIPTION
- Introduced a new `HttpLogger` middleware in `gapi/logger.go` to log HTTP request details, including method, path, status code, and duration.
- Updated `main.go` to utilize the new middleware, replacing the previous mux handler with the HTTP logger.
- Implemented a `ResponseRecorder` to capture response status codes and body for logging purposes.